### PR TITLE
Add functions for encrypting vec[u8] directly 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "xxtea"
 description = "XXTEA encryption algorithm library"
-authors = ["ambiguous404@gmail.com"]
+authors = ["ambiguous404@gmail.com", "daniel_digeraas@netile.se"]
 homepage = "https://crates.io/crates/xxtea"
 repository = "https://github.com/Hanaasagi/XXTEA-Rust"
-version = "0.1.1"
+version = "0.2.0"
 license = "MIT"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 mod xxtea;
 
-pub use xxtea::{encrypt, decrypt};
+pub use xxtea::{encrypt, decrypt, encrypt_raw, decrypt_raw};

--- a/src/xxtea.rs
+++ b/src/xxtea.rs
@@ -116,8 +116,7 @@ pub fn decrypt(data: &Vec<u8>, key: &str) -> Vec<u8> {
 }
 
 
-pub fn encrypt_raw(data: &str, key: &str) -> Vec<u8> {
-    let data = data.bytes().collect();
+pub fn encrypt_raw(data: &Vec<u8>, key: &str) -> Vec<u8> {
     let key = key.bytes().collect();
     to_bytes(&encrypt_(&mut to_u32(&data, false), &to_u32(&key, false)),
             false)

--- a/src/xxtea.rs
+++ b/src/xxtea.rs
@@ -115,13 +115,55 @@ pub fn decrypt(data: &Vec<u8>, key: &str) -> Vec<u8> {
             true)
 }
 
-
+/// Encrypt a u8 vector with XXTEA
+///
+/// *Note:* XXTEA works on 32 bit words. If input is not evenly dividable by
+/// four, it will be padded with zeroes. Padding information is lost after the
+/// encryption and this needs to be taken into consideration when decrypting
+/// messages.
+///
+/// # Arguments
+///
+/// * `data` - The data to be encrypted
+/// * `key` - encryption key
+///
+/// # Example
+///
+/// ```
+/// let key : &str = "SecretKey";
+/// let data : [u8; 5] = [11, 13, 0, 14, 15];
+///
+/// let encrypted_data = xxtea::encrypt_raw(&data.to_vec(), &key);
+/// // encrypted data will be 8 bytes (3 zeroes appended to the end)
+/// println!("Encrypted data: {:?}", encrypted_data);
+/// ```
+///
 pub fn encrypt_raw(data: &Vec<u8>, key: &str) -> Vec<u8> {
     let key = key.bytes().collect();
     to_bytes(&encrypt_(&mut to_u32(&data, false), &to_u32(&key, false)),
             false)
 }
 
+/// Decrypt a u8 vector with XXTEA
+///
+/// The output isn't verified for correctness, thus additional checks needs to
+/// be performed on the output.
+///
+/// # Arguments
+///
+/// * `data` - The data to be decrypted
+/// * `key` - encryption key
+///
+/// # Example
+///
+/// ```
+/// let key : &str = "SecretKey";
+/// let data : [u8; 5] = [11, 13, 0, 14, 15];
+///
+/// let decrypted_data = xxtea::decrypt_raw(&data.to_vec(), &key);
+/// println!("Decrypted data: {:?}", decrypted_data);
+/// ```
+///
 pub fn decrypt_raw(data: &Vec<u8>, key: &str) -> Vec<u8> {
     let key = key.bytes().collect();
     to_bytes(&decrypt_(&mut to_u32(&data, false), &to_u32(&key, false)),

--- a/src/xxtea.rs
+++ b/src/xxtea.rs
@@ -115,3 +115,17 @@ pub fn decrypt(data: &Vec<u8>, key: &str) -> Vec<u8> {
             true)
 }
 
+
+pub fn encrypt_raw(data: &str, key: &str) -> Vec<u8> {
+    let data = data.bytes().collect();
+    let key = key.bytes().collect();
+    to_bytes(&encrypt_(&mut to_u32(&data, false), &to_u32(&key, false)),
+            false)
+}
+
+pub fn decrypt_raw(data: &Vec<u8>, key: &str) -> Vec<u8> {
+    let key = key.bytes().collect();
+    to_bytes(&decrypt_(&mut to_u32(&data, false), &to_u32(&key, false)),
+            false)
+}
+

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -9,6 +9,13 @@ fn rand_string() -> String {
     (0..num).map(|_| rand::random::<char>()).collect()
 }
 
+pub fn to_hex_string(bytes: &[u8] ) -> String {
+    let strs: Vec<String> = bytes.iter()
+        .map(|b| format!("{:02X}", b))
+        .collect();
+
+    strs.join(" ")
+}
 
 fn run_test_case() {
     let data = rand_string();
@@ -23,6 +30,26 @@ fn run_test_case() {
     };
 
     assert_eq!(data, plain_text);
+}
+
+#[test]
+fn run_raw_test_case() {
+    let set1_unaligned : [u8; 10] = [17,  18, 19,  20, 0,  0,   0,  0,   52,  238];
+    let set1_encrypted : [u8; 12] = [153, 30, 118, 66, 15, 149, 77, 188, 228, 138, 105, 92];
+    let set1_aligned : [u8; 12]   = [17,  18, 19,  20, 0,  0,   0,  0,   52,  238, 0,   0];
+
+    let key = "Snakeoil";
+
+    let result1: Vec<u8> = xxtea::encrypt_raw(&set1_unaligned.to_vec(), &key);
+    let result2: Vec<u8> = xxtea::encrypt_raw(&set1_aligned.to_vec(), &key);
+
+    assert_eq!(result1, result2);
+    assert_eq!(result1, set1_encrypted.to_vec());
+
+    // Check that encrypted length is same as input length
+
+    let plain_bytes: Vec<u8> = xxtea::decrypt_raw(&result1, &key);
+    assert_eq!(plain_bytes, set1_aligned.to_vec());
 }
 
 #[test]


### PR DESCRIPTION
This addition makes so that XXTEA lib can be used together with encrypted data from embedded systems. The use case for this is to send small encrypted status messages over the air from an arduino to a raspberry pi with radio module. Further the new functions will not panic over assertion errors if the decrypted output isn't valid.